### PR TITLE
Wire frasermolyneux-copilot MCP server (v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,12 @@
 >
 > **Cloud agents (GitHub Copilot coding agent etc.):** read [`AGENTS.md`](../AGENTS.md) at the repo root first — it is the canonical brief that survives outside the local VS Code multi-root workspace.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 - **Architecture**: ASP.NET Core 9 API with Entra ID auth via Microsoft.Identity.Web. API startup lives in [src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/Program.cs](src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/Program.cs); controllers are versioned using Asp.Versioning and routed as `v{version:apiVersion}`.
 - **Projects**: Solution [src/XtremeIdiots.Portal.Integrations.Servers.sln](src/XtremeIdiots.Portal.Integrations.Servers.sln) includes Abstractions DTOs/interfaces, API, generated API client, and unit/integration tests.
 - **Authentication/Authorization**: Controllers are `[Authorize(Roles = "ServiceAccount")]`; ApiInfoController (`/v1.0/info`) and HealthController (`/v1.0/health`) allow anonymous. Ensure Entra audience/authority is configured in appsettings or environment.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup .NET
@@ -40,3 +41,12 @@ jobs:
             dotnet-version: |
               9.0.x
               10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: npm ci && npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ The `copilot-setup-steps.yml` workflow checks out `frasermolyneux/.github-copilo
 
 ---
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
+---
+
 ## Stack guardrails
 
 ### Tenant facts (always-on)

--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+This repo is wired to the shared `frasermolyneux-copilot` MCP server (pinned to tag `v0.1.0` of [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot)). The cloud-runner Copilot setup (`.github/workflows/copilot-setup-steps.yml`) checks out the catalog, builds the MCP server, and `.github/copilot/mcp_config.json` registers it for the GitHub Copilot coding agent. For local clients (VS Code, Claude Desktop, Copilot CLI) and tool-surface details, see [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/main/mcp-server/README.md).


### PR DESCRIPTION
## Summary

Wires the shared `frasermolyneux-copilot` MCP server into this repo (pinned to tag `v0.1.0` of `frasermolyneux/.github-copilot`), matching the template already merged into `portal-core`, so MCP-capable agents can fetch live org conventions instead of relying on stale file copies.

Closes #

## Type of change

- [ ] bugfix
- [ ] feature
- [x] chore / refactor
- [x] docs
- [ ] infra (Terraform)
- [x] ci (GitHub Actions / Dependabot)
- [ ] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

Also pulled the canonical bootstrap snippet from `metadata.copilot-instructions.instructions.md` (source-of-truth in `frasermolyneux/.github-copilot`).

## Validation evidence

This PR only touches CI workflow YAML, a JSON config, and three markdown files. There is no .NET / Terraform code path to exercise, so the relevant validations are parse + byte-identical snippet checks.

### Build

```text
N/A - no .NET/Terraform code changed.
```

### Tests

```text
N/A - no .NET/Terraform code changed.
```

### Format check

```text
JSON parse  (.github/copilot/mcp_config.json) : OK
YAML parse  (.github/workflows/copilot-setup-steps.yml) : OK
```

### Other (lint, terraform plan summary, screenshots)

Bootstrap snippet SHA256 equality check (LF-normalized) across all three locations:

```text
.github/copilot-instructions.md : len=1090  sha256=f14b266487487ac58b8e31cb59a4b62f8bc4d2ae00930c4de763d8eb6eb50c33
AGENTS.md                       : len=1090  sha256=f14b266487487ac58b8e31cb59a4b62f8bc4d2ae00930c4de763d8eb6eb50c33
canonical source (.github-copilot/.github/instructions/metadata.copilot-instructions.instructions.md)
                                : len=1090  sha256=f14b266487487ac58b8e31cb59a4b62f8bc4d2ae00930c4de763d8eb6eb50c33
Match files vs canonical: True
```

## Risk and rollout

- **Blast radius:** CI-only. Affects the GitHub Copilot coding agent's runner setup and any client that reads `.github/copilot/mcp_config.json`. No runtime / Azure impact. No published NuGet contract touched.
- **Auto-deploys on merge?** No. Workflow runs on push/PR that touches `copilot-setup-steps.yml`. No `deploy-dev` / `deploy-prd` triggered.
- **Manual steps post-merge:** None. Local clients (VS Code, Claude Desktop, Copilot CLI) that want the MCP server can follow `.github-copilot/mcp-server/README.md` independently.
- **Rollback plan:** Single commit revert. The pin to `v0.1.0` and the new build step are additive; reverting restores the previous unpinned checkout + dotnet-only setup.

## Reviewer focus areas

- The `ref: refs/tags/v0.1.0` pin is added to the existing `.github-copilot` checkout step only (not the repo-self checkout). Worth a quick eyeball of the YAML.
- Snippet placement in `.github/copilot-instructions.md` (after the cloud-agent callout, before the architecture bullets) and `AGENTS.md` (between the `---` separator after "Required reading" and `## Stack guardrails`) is intentional but feel free to suggest moving it.
- `npm ci` in `.github-copilot/mcp-server` relies on the upstream `package-lock.json` existing at tag `v0.1.0` — confirmed present.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)