### PR TITLE
deps: roll to Repository client 4.2.22 and re-enable consumer L1 caching with boot smoke test

### DIFF
--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1/RepositoryApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1/RepositoryApiClientRegistrationTests.cs
@@ -1,0 +1,214 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+using MX.Api.Client.Caching;
+
+using XtremeIdiots.Portal.Integrations.Servers.Api.V1.Registration;
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Api.Client.V1;
+
+namespace XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1;
+
+/// <summary>
+/// Startup-composition regression test for the Portal Repository API client.
+/// </summary>
+/// <remarks>
+/// Repository client 4.2.21 (on MX.Api.Client 2.3.76) fanned a single cache
+/// delegate across every typed sub-API registration. When library caching
+/// defaults were enabled on the consumer, host DI resolution crashed at
+/// startup with
+/// <c>System.ArgumentException: The expression must invoke a method declared by ...IAdminActionsApi ...</c>.
+/// PR #1021 hotfixed production by removing the consumer <c>.WithCaching(...)</c>.
+/// <para>
+/// Repository client 4.2.22 (on MX.Api.Client 2.3.77) resolves the root cause
+/// via a reflection-free <c>SharedCacheConfiguration</c> that scopes each
+/// cache policy to its matching typed sub-API. This test exercises two
+/// registration entry points that would have failed against the crashing
+/// 4.2.21 / 2.3.76 pair:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <description>
+///       Booting the real <c>Program.cs</c> host through
+///       <see cref="WebApplicationFactory{TEntryPoint}"/> — the same code path
+///       that took down production — and resolving <see cref="IRepositoryApiClient"/>
+///       plus every typed sub-API this service consumes, including
+///       <c>IAdminActionsApi</c> (the interface named in the historical
+///       ArgumentException).
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       Building a lightweight <see cref="ServiceCollection"/> via the shared
+///       <see cref="RepositoryApiClientRegistration.AddPortalRepositoryApiClient"/>
+///       extension with <c>ValidateOnBuild = true</c> so a container-level
+///       misconfiguration is caught even when the WebApplicationFactory path is
+///       skipped (e.g. faster local dev loops).
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// Lives in the unit-tests project so it runs under the default CI filter
+/// (<c>FullyQualifiedName!~IntegrationTests</c>).
+/// </para>
+/// </remarks>
+[Trait("Category", "Unit")]
+public class RepositoryApiClientRegistrationTests : IClassFixture<RepositoryApiClientRegistrationTests.HostBootFactory>
+{
+    private readonly HostBootFactory _factory;
+
+    public RepositoryApiClientRegistrationTests(HostBootFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public void HostBoot_Resolves_IRepositoryApiClient()
+    {
+        // Materialising the factory's Services property drives the full Program.cs
+        // pipeline. Any registration-time crash — including the historical
+        // 4.2.21 / 2.3.76 ArgumentException against IAdminActionsApi — surfaces here.
+        using var scope = _factory.Services.CreateScope();
+
+        var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void HostBoot_Resolves_AllTypedSubClientsThisHostConsumes()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+
+        // IAdminActionsApi is the exact sub-API the 4.2.21 / 2.3.76 crash reported
+        // in its ArgumentException — materialising it here is the regression assertion.
+        Assert.NotNull(client.AdminActions);
+        Assert.NotNull(client.AdminActions.V1);
+
+        // Every typed sub-API this host actually calls from controllers / helpers.
+        Assert.NotNull(client.GameServers.V1);
+        Assert.NotNull(client.Maps.V1);
+        Assert.NotNull(client.GameServerConfigurations.V1);
+        Assert.NotNull(client.GameServersEvents.V1);
+    }
+
+    [Fact]
+    public void HostBoot_Registers_LibraryCacheDefaults_ForCachedSubClients()
+    {
+        // The 4.2.22 library caching defaults register a DefaultCachePolicies<T>
+        // per typed sub-API the Repository client caches. If a future refactor
+        // silently drops the consumer .WithCaching(...) call these resolutions
+        // return null and the L1 cache benefit is gone — this test catches that.
+        using var scope = _factory.Services.CreateScope();
+
+        var gameServersPolicies = scope.ServiceProvider.GetService<DefaultCachePolicies<IGameServersApi>>();
+        var mapsPolicies = scope.ServiceProvider.GetService<DefaultCachePolicies<IMapsApi>>();
+
+        Assert.NotNull(gameServersPolicies);
+        Assert.NotEmpty(gameServersPolicies!.Policies);
+
+        Assert.NotNull(mapsPolicies);
+        Assert.NotEmpty(mapsPolicies!.Policies);
+    }
+
+    [Fact]
+    public void SharedRegistration_Extension_BuildsValidatedContainer()
+    {
+        // Independent, host-free assertion: the shared extension that Program.cs
+        // uses must produce a container that passes ValidateOnBuild, so a plain
+        // dotnet-test invocation without the WebApplicationFactory path still
+        // catches container-level misconfiguration in the client's DI wiring.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [RepositoryApiClientRegistration.BaseUrlConfigurationKey] = "https://localhost/repository",
+                [RepositoryApiClientRegistration.AudienceConfigurationKey] = "api://test-repository"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddLogging(b => b.AddProvider(NullLoggerProvider.Instance));
+        services.AddMemoryCache();
+
+        services.AddPortalRepositoryApiClient(configuration, cachePartition: "boot-smoke-test");
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+
+        using var scope = provider.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+        Assert.NotNull(client);
+        Assert.NotNull(client.AdminActions.V1);
+    }
+
+    /// <summary>
+    /// <see cref="WebApplicationFactory{TEntryPoint}"/> that keeps the real
+    /// Repository API client registration intact so a crash in the client
+    /// library's DI wiring reproduces here rather than in production.
+    /// </summary>
+    public sealed class HostBootFactory : WebApplicationFactory<Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Testing");
+
+            builder.UseSetting("RepositoryApi:BaseUrl", "https://localhost/repository");
+            builder.UseSetting("RepositoryApi:ApplicationAudience", "api://test-repository");
+            builder.UseSetting(
+                "ApplicationInsights:ConnectionString",
+                "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost/;LiveEndpoint=https://localhost/");
+            builder.UseSetting("ServiceBusConnection:fullyQualifiedNamespace", "test.servicebus.windows.net");
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication("Test")
+                    .AddScheme<AuthenticationSchemeOptions, HostBootTestAuthHandler>("Test", _ => { });
+
+                services.PostConfigure<AuthenticationOptions>(options =>
+                {
+                    options.DefaultAuthenticateScheme = "Test";
+                    options.DefaultChallengeScheme = "Test";
+                });
+            });
+        }
+    }
+
+    internal sealed class HostBootTestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public HostBootTestAuthHandler(
+            IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger,
+            UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var identity = new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.Name, "TestUser"),
+                    new Claim(ClaimTypes.Role, "ServiceAccount")
+                },
+                "Test");
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), "Test");
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.csproj
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.18" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Moq" Version="4.20.72" />

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/Program.cs
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/Program.cs
@@ -10,12 +10,12 @@ using XtremeIdiots.Portal.Integrations.Servers.Api.V1;
 using XtremeIdiots.Portal.Integrations.Servers.Api.Factories.V1;
 using XtremeIdiots.Portal.Integrations.Servers.Api.Interfaces.V1;
 using Asp.Versioning;
-using XtremeIdiots.Portal.Repository.Api.Client.V1;
 using MX.Observability.ApplicationInsights.AspNetCore;
 using Scalar.AspNetCore;
 using XtremeIdiots.Portal.Integrations.Servers.Api.V1.OpenApi;
 using XtremeIdiots.Portal.Integrations.Servers.Api.V1.Helpers;
 using XtremeIdiots.Portal.Integrations.Servers.Api.V1.Publishing;
+using XtremeIdiots.Portal.Integrations.Servers.Api.V1.Registration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -107,9 +107,7 @@ builder.Services.AddSingleton<IRconClientFactory, RconClientFactory>();
 builder.Services.AddScoped<IFileTransportResolver, FileTransportResolver>();
 builder.Services.AddScoped<IGameServerFileTransportFactory, GameServerFileTransportFactory>();
 
-builder.Services.AddRepositoryApiClient(options => options
-    .WithBaseUrl(builder.Configuration["RepositoryApi:BaseUrl"] ?? throw new InvalidOperationException("RepositoryApi:BaseUrl configuration is required"))
-    .WithEntraIdAuthentication(builder.Configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required")));
+builder.Services.AddPortalRepositoryApiClient(builder.Configuration, builder.Environment.ApplicationName);
 
 builder.Services.AddSingleton(sp =>
 {

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/Registration/RepositoryApiClientRegistration.cs
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/Registration/RepositoryApiClientRegistration.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using XtremeIdiots.Portal.Repository.Api.Client.V1;
+
+namespace XtremeIdiots.Portal.Integrations.Servers.Api.V1.Registration;
+
+/// <summary>
+/// Encapsulates the Portal Repository API client DI registration for this host so that
+/// Program.cs and the startup-composition regression tests exercise the exact same
+/// registration path.
+/// </summary>
+/// <remarks>
+/// The client is registered with base URL + Entra ID auth and opts into the
+/// Repository client (4.2.22) library caching defaults, which are backed by
+/// MX.Api.Client 2.3.77's reflection-free <c>SharedCacheConfiguration</c>. Each
+/// cache policy is scoped to the typed sub-API it targets, so this no longer
+/// reproduces the 4.2.21 / MX.Api.Client 2.3.76 cross-sub-API expression crash
+/// that took down consumers with an <c>ArgumentException</c> against
+/// <c>IAdminActionsApi</c> at startup.
+/// <para>
+/// Cached surface (per the Repository client's library defaults):
+/// short-TTL single/list reads on <c>IGameServersApi</c> and longer-TTL reads on
+/// <c>IMapsApi</c>. Every method this host invokes on those sub-APIs is a plain
+/// read with no in-request follow-up write, so cached responses can never mask a
+/// mutation performed by this service (this service never writes game servers or
+/// maps — it only reads them to look up transport settings, resolve map metadata,
+/// and drive RCON/query flows).
+/// </para>
+/// </remarks>
+internal static class RepositoryApiClientRegistration
+{
+    /// <summary>
+    /// Configuration key holding the Repository API base URL.
+    /// </summary>
+    internal const string BaseUrlConfigurationKey = "RepositoryApi:BaseUrl";
+
+    /// <summary>
+    /// Configuration key holding the Repository API Entra ID audience.
+    /// </summary>
+    internal const string AudienceConfigurationKey = "RepositoryApi:ApplicationAudience";
+
+    /// <summary>
+    /// Registers the Portal Repository API client with the same options wiring used by
+    /// <c>Program.cs</c>. The <paramref name="cachePartition"/> should be the host
+    /// application name so cache entries are isolated per consumer.
+    /// </summary>
+    public static IServiceCollection AddPortalRepositoryApiClient(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string cachePartition)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(cachePartition);
+
+        var baseUrl = configuration[BaseUrlConfigurationKey]
+            ?? throw new InvalidOperationException($"{BaseUrlConfigurationKey} configuration is required");
+        var audience = configuration[AudienceConfigurationKey]
+            ?? throw new InvalidOperationException($"{AudienceConfigurationKey} configuration is required");
+
+        services.AddRepositoryApiClient(options => options
+            .WithBaseUrl(baseUrl)
+            .WithEntraIdAuthentication(audience)
+            .WithCachePartition(cachePartition)
+            .WithCaching(c => c.UseLibraryDefaults()));
+
+        return services;
+    }
+}

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/XtremeIdiots.Portal.Integrations.Servers.Api.V1.csproj
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/XtremeIdiots.Portal.Integrations.Servers.Api.V1.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="4.13.2" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
-      <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
-      <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.22" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.22" />
     <PackageReference Include="XtremeIdiots.Portal.Server.Events.Abstractions.V1" Version="1.1.168" />
     <PackageReference Include="XtremeIdiots.Portal.Settings.Contracts.V1" Version="4.2.13" />
   </ItemGroup>

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/XtremeIdiots.Portal.Integrations.Servers.Api.V1.csproj
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/XtremeIdiots.Portal.Integrations.Servers.Api.V1.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
-    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.77" />
+    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.77" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.18" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.16.16" />
@@ -34,8 +34,8 @@
     <PackageReference Include="Microsoft.Identity.Web" Version="4.13.2" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
-      <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.21" />
-      <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.21" />
+      <PackageReference Include="XtremeIdiots.Portal.Repository.Abstractions.V1" Version="4.2.22" />
+      <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.22" />
     <PackageReference Include="XtremeIdiots.Portal.Server.Events.Abstractions.V1" Version="1.1.168" />
     <PackageReference Include="XtremeIdiots.Portal.Settings.Contracts.V1" Version="4.2.13" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Roll to Portal Repository client `4.2.22` (MX.Api.Client `2.3.77`), re-enable the consumer L1 caching that hotfix PR #1021 removed, and add a startup-composition smoke test that boots the real host and would fail if the historic cross-sub-API cache scoping ever regresses.

Follow-up to #1019 (rollout that crashed) and #1021 (hotfix that removed caching).

## Type of change

- [x] Dependency bump / cleanup
- [x] New tests / test infrastructure
- [x] Bug fix (regression guard — prevents the #1019 crash from re-happening)

## Validation evidence

**Unit tests (`net9.0`) — default filter, includes the new boot smoke tests**

```
> dotnet test src/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1/XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.csproj -f net9.0 --nologo
Passed!  - Failed:     0, Passed:   130, Skipped:     0, Total:   130, Duration: 26 s - XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.dll (net9.0)
```

**New boot smoke tests specifically**

```
> dotnet test ... --filter "FullyQualifiedName~RepositoryApiClientRegistrationTests"
Passed!  - Failed:     0, Passed:     4, Skipped:     0, Total:     4, Duration: 547 ms
```

Tests exercised:
- `HostBoot_Resolves_IRepositoryApiClient`
- `HostBoot_Resolves_AllTypedSubClientsThisHostConsumes` (asserts `IAdminActionsApi`, `IGameServersApi`, `IMapsApi`, `IGameServerConfigurationsApi`, `IGameServersEventsApi` V1)
- `HostBoot_Registers_LibraryCacheDefaults_ForCachedSubClients` (asserts `DefaultCachePolicies<IGameServersApi>` / `<IMapsApi>` presence and non-empty policies)
- `SharedRegistration_Extension_BuildsValidatedContainer` (host-free `ValidateOnBuild = true` guard on the shared extension)

**Client / Testing tests (default filter run against the solution)**

```
Passed!  - Failed:     0, Passed:    60, Skipped:     0, Total:    60, Duration: 336 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:    60, Skipped:     0, Total:    60, Duration: 429 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:   129, Skipped:     0, Total:   129, Duration: 27 s - XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.dll (net9.0)
Passed!  - Failed:     0, Passed:   129, Skipped:     0, Total:   129, Duration: 28 s - XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.dll (net10.0)
Passed!  - Failed:     0, Passed:    27, Skipped:     0, Total:    27, Duration: 607 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.dll (net9.0)
Passed!  - Failed:     0, Passed:    27, Skipped:     0, Total:    27, Duration: 611 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.dll (net10.0)
```

**Build**

```
> dotnet build src/XtremeIdiots.Portal.Integrations.Servers.Api.V1/XtremeIdiots.Portal.Integrations.Servers.Api.V1.csproj -v minimal
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

**Format**

```
> dotnet format src/XtremeIdiots.Portal.Integrations.Servers.sln --verify-no-changes
(no violations reported)
```

> Note: the local Windows-worktree `dotnet build` on the full `.sln` hits a pre-existing nbgv `MSB3030` race on `Api.Client.IntegrationTests.V1` (`.Version.cs.new` file not found). Verified by stashing this PR's changes on the branch tip — the same failure reproduces on unmodified `origin/main`. Not caused by this PR, does not occur in CI (Linux).

## Risk and rollout

- **Blast radius:** single host — `XtremeIdiots.Portal.Integrations.Servers.Api.V1`. No changes to published `Abstractions`/`Client` NuGet contracts and no schema/migration work.
- **Auto-deploy?** Yes on merge to `main` via `deploy-prd`.
- **Manual steps post-merge:** none.
- **Rollback plan:** revert this PR. The uncached shape from PR #1021 is a safe fallback. If a caching-only regression appears in production after 4.2.22 rollout, the config keys `RepositoryApi:BaseUrl` / `RepositoryApi:ApplicationAudience` stay unchanged so a hotfix that removes the `.WithCaching(...)` call from `RepositoryApiClientRegistration` is a one-line patch.

## Consumer impact

Not applicable — no changes to published Abstractions/Client NuGets or Service Bus DTOs. Terraform outputs unchanged.

## Agent attestation

- [x] `dotnet build` succeeds on the API project (clean)
- [x] `dotnet test --filter "FullyQualifiedName!~IntegrationTests"` passes locally, new boot smoke tests included
- [x] `dotnet format --verify-no-changes` passes
- [x] `terraform fmt -check -recursive` / `validate` unchanged (no terraform in this diff)
- [x] No published contract change
- [x] No secrets / new GUIDs / connection strings introduced
- [x] `code-review` sub-agent run — no High/Medium findings
- [x] Cached surface manually audited: this service only reads `GameServers.V1` / `Maps.V1` / `GameServerConfigurations.V1` and pushes uncached `GameServersEvents.V1` events. No writes on any cached sub-API and no read-after-write within a request.