### PR TITLE
deps: adopt MX.Api.Client 2.3.77 SharedCacheConfiguration in servers client library

### DIFF
--- a/src/XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1/XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1.csproj
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1/XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
 	<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
-	<PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+	<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing.csproj
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
   </ItemGroup>
 

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1/ServersApiClientDITests.cs
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1/ServersApiClientDITests.cs
@@ -1,8 +1,11 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using MX.Api.Abstractions;
 using MX.Api.Client.Auth;
 using MX.Api.Client.Configuration;
 using XtremeIdiots.Portal.Integrations.Servers.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Integrations.Servers.Abstractions.Models.V1.Maps;
+using XtremeIdiots.Portal.Integrations.Servers.Abstractions.Models.V1.Rcon;
 using XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1;
 
 namespace XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1;
@@ -225,5 +228,117 @@ public class ServersApiClientDITests
 
         Assert.NotNull(filesApi);
         Assert.NotNull(filesApi.V1);
+    }
+
+    /// <summary>
+    /// Regression test: registering caching expressions targeting two different sub-API interfaces
+    /// (Cod4 Rcon and Maps) must not throw during registration or provider build. Prior to the
+    /// SharedCacheConfiguration wiring, MX.Api.Client's per-typed-client scoping would throw
+    /// <see cref="ArgumentException"/> during startup on the first sub-API whose declaring type did
+    /// not match the expression.
+    /// </summary>
+    [Fact]
+    public void ServersApiClient_CachingAcrossMultipleSubApis_DoesNotThrowAndResolvesAll()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddServersApiClient(options =>
+        {
+            options
+                .WithBaseUrl("https://localhost")
+                .WithEntraIdAuthentication("api://servers-tests")
+                .WithCachePartition("unit-tests")
+                .WithCaching(c => c
+                    .NotCached<ICod4RconApi, Task<ApiResult<RconStatusResponseDto>>>(x => x.Status(Guid.Empty, default))
+                    .NotCached<IMapsApi, Task<ApiResult<ServerMapsCollectionDto>>>(x => x.GetLoadedServerMapsFromHost(Guid.Empty)));
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<IQueryApi>());
+        Assert.NotNull(provider.GetRequiredService<ICoD4xRconApi>());
+        Assert.NotNull(provider.GetRequiredService<ICod2RconApi>());
+        Assert.NotNull(provider.GetRequiredService<ICod4RconApi>());
+        Assert.NotNull(provider.GetRequiredService<ICod5RconApi>());
+        Assert.NotNull(provider.GetRequiredService<IInsurgencyRconApi>());
+        Assert.NotNull(provider.GetRequiredService<IRustRconApi>());
+        Assert.NotNull(provider.GetRequiredService<IL4d2RconApi>());
+        Assert.NotNull(provider.GetRequiredService<IMapsApi>());
+        Assert.NotNull(provider.GetRequiredService<IApiInfoApi>());
+        Assert.NotNull(provider.GetRequiredService<IApiHealthApi>());
+        Assert.NotNull(provider.GetRequiredService<IConfigApi>());
+        Assert.NotNull(provider.GetRequiredService<IFileBrowseApi>());
+        Assert.NotNull(provider.GetRequiredService<IFilesApi>());
+        Assert.NotNull(provider.GetRequiredService<IServersApiClient>());
+    }
+
+    /// <summary>
+    /// Typo-guard: a cache expression targeting an interface that is never registered as a typed
+    /// sub-API must surface an <see cref="InvalidOperationException"/> from
+    /// <c>SharedCacheConfiguration.ValidateAllOperationsMatched()</c> during registration, rather
+    /// than silently no-op'ing.
+    /// </summary>
+    [Fact]
+    public void ServersApiClient_CachingWithUnregisteredInterface_ThrowsInvalidOperation()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var thrown = Assert.Throws<InvalidOperationException>(() =>
+        {
+            services.AddServersApiClient(options =>
+            {
+                options
+                    .WithBaseUrl("https://localhost")
+                    .WithCachePartition("unit-tests")
+                    .WithCaching(c => c
+                        .NotCached<IBogusUnregisteredApi, Task<string>>(x => x.DoThing()));
+            });
+        });
+
+        Assert.NotNull(thrown);
+    }
+
+    /// <summary>
+    /// No-caching path: registration without <c>WithCaching</c> must still resolve all typed
+    /// sub-APIs and the unified client.
+    /// </summary>
+    [Fact]
+    public void ServersApiClient_NoCachingConfigured_ResolvesAllSubApis()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddServersApiClient(options =>
+        {
+            options
+                .WithBaseUrl("https://localhost")
+                .WithEntraIdAuthentication("api://servers-tests");
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetRequiredService<IQueryApi>());
+        Assert.NotNull(provider.GetRequiredService<ICoD4xRconApi>());
+        Assert.NotNull(provider.GetRequiredService<ICod2RconApi>());
+        Assert.NotNull(provider.GetRequiredService<ICod4RconApi>());
+        Assert.NotNull(provider.GetRequiredService<ICod5RconApi>());
+        Assert.NotNull(provider.GetRequiredService<IInsurgencyRconApi>());
+        Assert.NotNull(provider.GetRequiredService<IRustRconApi>());
+        Assert.NotNull(provider.GetRequiredService<IL4d2RconApi>());
+        Assert.NotNull(provider.GetRequiredService<IMapsApi>());
+        Assert.NotNull(provider.GetRequiredService<IApiInfoApi>());
+        Assert.NotNull(provider.GetRequiredService<IApiHealthApi>());
+        Assert.NotNull(provider.GetRequiredService<IConfigApi>());
+        Assert.NotNull(provider.GetRequiredService<IFileBrowseApi>());
+        Assert.NotNull(provider.GetRequiredService<IFilesApi>());
+        Assert.NotNull(provider.GetRequiredService<IServersApiClient>());
+    }
+
+    // Deliberately unregistered interface used only by the typo-guard test above.
+    public interface IBogusUnregisteredApi
+    {
+        Task<string> DoThing();
     }
 }

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1/ServersApiClientOptionsBuilder.cs
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1/ServersApiClientOptionsBuilder.cs
@@ -1,11 +1,28 @@
+using System;
 using MX.Api.Client.Configuration;
 
 namespace XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1
 {
     /// <summary>
-    /// Builder for configuring Servers API client options
+    /// Builder for configuring Servers API client options.
     /// </summary>
+    /// <remarks>
+    /// Overrides <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithCaching(Action{CacheBuilder})"/>
+    /// to capture the consumer's cache configuration so
+    /// <see cref="ServiceCollectionExtensions.AddServersApiClient"/> can promote it into a
+    /// <see cref="SharedCacheConfiguration"/> that is applied across every typed sub-API. This avoids the
+    /// per-typed-client scoping crash you get if the same delegate is applied via
+    /// <c>AddTypedApiClient</c> multiple times with expressions targeting different sub-API interfaces.
+    /// </remarks>
     public class ServersApiClientOptionsBuilder : ApiClientOptionsBuilder<ServersApiClientOptions, ServersApiClientOptionsBuilder>
     {
+        internal Action<CacheBuilder>? CapturedCacheConfigure { get; private set; }
+
+        public new ServersApiClientOptionsBuilder WithCaching(Action<CacheBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure);
+            CapturedCacheConfigure = configure;
+            return this;
+        }
     }
 }

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1/ServiceCollectionExtensions.cs
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using MX.Api.Client.Configuration;
 using MX.Api.Client.Extensions;
 using XtremeIdiots.Portal.Integrations.Servers.Abstractions.Interfaces.V1;
 
@@ -8,31 +9,57 @@ namespace XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1
     {
         public static IServiceCollection AddServersApiClient(this IServiceCollection serviceCollection, Action<ServersApiClientOptionsBuilder> configureOptions)
         {
+            ArgumentNullException.ThrowIfNull(serviceCollection);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+
+            // Run the consumer's configuration against a probe builder so we can lift any WithCaching
+            // delegate into a SharedCacheConfiguration. MX.Api.Client scopes each ApiClientOptionsBuilder
+            // to a single typed client, so applying the same multi-interface WithCaching expression via
+            // AddTypedApiClient per sub-API crashes at startup. WithSharedCaching applies only the
+            // operations whose declaring interface matches the current typed client and skips siblings.
+            var probe = new ServersApiClientOptionsBuilder();
+            configureOptions(probe);
+            var capturedCache = probe.CapturedCacheConfigure;
+            var sharedCache = capturedCache is null ? null : new SharedCacheConfiguration(capturedCache);
+
+            Action<ServersApiClientOptionsBuilder> perClient = sharedCache is null
+                ? configureOptions
+                : builder =>
+                {
+                    configureOptions(builder);
+                    builder.WithSharedCaching(sharedCache);
+                };
+
             // Register V1 API implementations using the new typed pattern
-            serviceCollection.AddTypedApiClient<IQueryApi, QueryApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ICoD4xRconApi, CoD4xRconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ICod2RconApi, Cod2RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ICod4RconApi, Cod4RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<ICod5RconApi, Cod5RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IInsurgencyRconApi, InsurgencyRconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IRustRconApi, RustRconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IL4d2RconApi, L4d2RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
-            serviceCollection.AddTypedApiClient<IMapsApi, MapsApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IQueryApi, QueryApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ICoD4xRconApi, CoD4xRconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ICod2RconApi, Cod2RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ICod4RconApi, Cod4RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<ICod5RconApi, Cod5RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IInsurgencyRconApi, InsurgencyRconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IRustRconApi, RustRconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IL4d2RconApi, L4d2RconApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+            serviceCollection.AddTypedApiClient<IMapsApi, MapsApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
 
             // Register API info endpoint
-            serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
 
             // Register API health endpoint
-            serviceCollection.AddTypedApiClient<IApiHealthApi, ApiHealthApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IApiHealthApi, ApiHealthApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
 
             // Register Config API endpoint
-            serviceCollection.AddTypedApiClient<IConfigApi, ConfigApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IConfigApi, ConfigApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
 
             // Register transport-neutral browse endpoint.
-            serviceCollection.AddTypedApiClient<IFileBrowseApi, FileBrowseApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IFileBrowseApi, FileBrowseApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
 
             // Register transport-neutral generic files endpoints.
-            serviceCollection.AddTypedApiClient<IFilesApi, FilesApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(configureOptions);
+            serviceCollection.AddTypedApiClient<IFilesApi, FilesApi, ServersApiClientOptions, ServersApiClientOptionsBuilder>(perClient);
+
+            // Fail fast on typos: any cache operation whose declaring interface never matched a registered
+            // typed client (e.g. an unregistered/renamed sub-API) throws InvalidOperationException here
+            // rather than silently no-op'ing.
+            sharedCache?.ValidateAllOperationsMatched();
 
             // Register version selectors as scoped
             serviceCollection.AddScoped<IVersionedQueryApi, VersionedQueryApi>();

--- a/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1.csproj
+++ b/src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1/XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1.csproj
@@ -27,7 +27,7 @@
   <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
 	<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
-	<PackageReference Include="MX.Api.Client" Version="2.3.67" />
+	<PackageReference Include="MX.Api.Client" Version="2.3.77" />
 	<PackageReference Include="RestSharp" Version="114.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adopt the reflection-free "shared cache configuration" registration pattern (MX.Api.Client 2.3.77) in the servers API client library so consumers can compose a single `.WithCaching(...)` expression that targets any of the 14 typed sub-APIs without hitting MX.Api.Client's per-typed-client scoping crash. Bumps `MX.Api.Client` / `MX.Api.Abstractions` from 2.3.67 to 2.3.77 across the 3 packaged projects (`Abstractions.V1`, `Api.Client.V1`, `Api.Client.Testing`).

Closes #

## Type of change

- [x] chore / refactor
- [x] dependencies

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

## Validation evidence

### Build

```text
$ dotnet build src/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1/XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.csproj
XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1 -> ...\net9.0\XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1.dll
XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1 -> ...\net10.0\XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1.dll
XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1 -> ...\net9.0\XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1.dll
XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1 -> ...\net10.0\XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1.dll
XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1 -> ...\net9.0\XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.dll
XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1 -> ...\net10.0\XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

Full-solution build succeeded for every project except the pre-existing Nerdbank.GitVersioning MSB3030 race on `Api.Client.IntegrationTests.V1` in this local worktree; the same failure reproduces on `origin/main` unchanged, is unrelated to this PR, and the project contains no default-filter tests.

### Tests

```text
$ dotnet test src/XtremeIdiots.Portal.Integrations.Servers.sln --filter "FullyQualifiedName!~IntegrationTests"
Passed!  - Failed:     0, Passed:    30, Skipped:     0, Total:    30, Duration: 282 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.dll (net9.0)
Passed!  - Failed:     0, Passed:    30, Skipped:     0, Total:    30, Duration: 276 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Tests.V1.dll (net10.0)
Passed!  - Failed:     0, Passed:    60, Skipped:     0, Total:    60, Duration: 236 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:    60, Skipped:     0, Total:    60, Duration: 244 ms - XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing.Tests.dll (net10.0)
Passed!  - Failed:     0, Passed:   130, Skipped:     0, Total:   130, Duration: 26 s  - XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.dll (net9.0)
Passed!  - Failed:     0, Passed:   130, Skipped:     0, Total:   130, Duration: 26 s  - XtremeIdiots.Portal.Integrations.Servers.Api.Tests.V1.dll (net10.0)
```

Three new tests in `ServersApiClientDITests` (crash-guard, typo-guard, no-caching) are included in the 30-test client suite on both TFMs.

### Format check

```text
$ dotnet format src/XtremeIdiots.Portal.Integrations.Servers.sln --verify-no-changes
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
EXIT=0
```

## Risk and rollout

- **Blast radius:** Published client library `XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1` (and the two co-versioned NuGet packages). No API host behaviour changes; the host's repository-client caching path was fixed and deployed separately and is untouched here.
- **Auto-deploys on merge?** No. NuGet publish runs from the release workflows on tagged releases; this merge only lands on `main`.
- **Manual steps post-merge:** None. Consumers must reference the new client version and can (optionally) add a single `.WithCaching(c => c.NotCached<IFooApi, ...>(x => x.Foo(...)) ...)` expression against any combination of sub-APIs.
- **Rollback plan:** Revert this commit; no data/state migrated, no infra changed. NuGet-side rollback = ship the previous 2.3.67-based build.

## Consumer impact

- **Contracts touched:** `XtremeIdiots.Portal.Integrations.Servers.Api.Client.V1`, `XtremeIdiots.Portal.Integrations.Servers.Abstractions.V1`, `XtremeIdiots.Portal.Integrations.Servers.Api.Client.Testing` — package reference bumps `MX.Api.Client` / `MX.Api.Abstractions` 2.3.67 → 2.3.77.
- **Breaking?** No. The public builder API is source-compatible: `ServersApiClientOptionsBuilder.WithCaching(Action<CacheBuilder>)` still exists and still returns the derived builder; the change is that the delegate is now captured and promoted to `SharedCacheConfiguration` internally.
- **Downstream consumers:** portal-web-app, any other repo consuming `IServersApiClient` DI.
- **Migration notes:** Consumers previously prevented from adding any `.WithCaching` because it crashed under multi-sub-API scoping can now compose one expression targeting multiple sub-API interfaces. No default cache policies are shipped — this PR is version currency + scoping-safe pattern only. Consumers wanting caching must opt in explicitly.

### Cache defaults decision

No default cache policies are registered in this PR — every sub-API on this client is one of:
- Live server RCON command execution: `ICoD4xRconApi`, `ICod2RconApi`, `ICod4RconApi`, `ICod5RconApi`, `IInsurgencyRconApi`, `IRustRconApi`, `IL4d2RconApi` — never cacheable, side-effectful.
- Live game-server query state: `IQueryApi` — freshness-sensitive, host caches for 5 min already at controller level.
- Live file-transport host state: `IMapsApi` (`GetLoadedServerMapsFromHost`, `PushServerMapToHost`, `DeleteServerMapFromHost`, `VerifyServerMaps`) — read-after-write sensitive; the collection read is invalidated by the push/delete siblings in the same interface.
- File / config surfaces: `IFileBrowseApi`, `IFilesApi`, `IConfigApi` — mutation + read-after-write sensitive.
- Info / health: `IApiInfoApi`, `IApiHealthApi` — extremely low call volume from typical consumers (once at startup / on liveness probe path); default caching adds cache infra overhead without observable win.

## Reviewer focus areas

- Correctness of the probe-then-share pattern in `ServiceCollectionExtensions.AddServersApiClient` — the consumer's `configureOptions` delegate is now invoked 15 times (probe + 14 typed clients) instead of 14. This is safe because `AddTypedApiClient` already required the delegate be re-invokable per typed client.
- The `new WithCaching` override in `ServersApiClientOptionsBuilder` intercepts on all call paths because every base fluent method is declared to return `TBuilder` (= `ServersApiClientOptionsBuilder`), so static-typed chains land on the derived override.
- `SharedCacheConfiguration.ValidateAllOperationsMatched()` is called after the last `AddTypedApiClient`. This is the correct placement per MX.Api.Client 2.3.77 — `WithSharedCaching` records interface matches eagerly per typed client, so validation sees the fully-populated match set (the typo-guard test confirms this by expecting `InvalidOperationException` for a bogus interface).

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)
